### PR TITLE
add identation wrapping - client side (#25)

### DIFF
--- a/cnew.py
+++ b/cnew.py
@@ -1,9 +1,12 @@
 import asyncio, websockets, time, json, click, secrets, os, sys
+from typing import List
 from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit import print_formatted_text, HTML
 from prompt_toolkit.validation import Validator, ValidationError
 from cryptography.fernet import Fernet, InvalidToken
+
+import textwrap
 
 
 sess = PromptSession()
@@ -38,7 +41,8 @@ async def consumer_handler(cphrsuit, websocket, username, chatroom, servaddr):
             else:
                 recvjson = json.loads(cphrsuit.decrjson(recvdata))
                 if recvjson["chatroom"] == chatroom and recvjson["username"] != username:
-                    print("[" + obtntime() + "] " + formusnm(recvjson["username"]) + " > " + recvjson["mesgtext"])
+                    display_mesgtext(recvjson["username"], recvjson["mesgtext"])
+
         except Exception as EXPT:
             pass
 
@@ -62,6 +66,32 @@ async def hello(servaddr, username, chatroom, password):
         await prod
         await cons
         asyncio.get_event_loop().run_forever()
+
+
+def wrap_msgtext(mesgtext: str, set_width: int = 80) -> List[str]:
+    """ Wrap text into list
+        text length is set and determined as a breakpoint
+    """
+    if not isinstance(mesgtext, str):
+        return []
+    return textwrap.wrap(mesgtext, width=set_width)
+
+
+def display_mesgtext(username: str, mesgtext: str) -> None:
+    """ Display user text on client side """
+    if not all([isinstance(mesgtext, str), isinstance(mesgtext, str)]):
+        return None
+
+    wrapped_lines = wrap_msgtext(mesgtext)
+    for idx, line in enumerate(wrapped_lines):
+        filling_username = formusnm(''.join([' ' for _ in range(len(username))]))
+        if idx == 0:
+            recv_template = f"[{obtntime()}] {formusnm(username)} > {line}"
+        else:
+            recv_template = f"[{obtntime()}] {formusnm(filling_username)} > {line}"
+        print(recv_template)
+
+    return None
 
 
 def obtntime():

--- a/cnew.py
+++ b/cnew.py
@@ -85,9 +85,8 @@ def display_mesgtext(username: str, mesgtext: str) -> None:
     wrapped_lines = wrap_msgtext(mesgtext)
     for idx, line in enumerate(wrapped_lines):
         filling_username = formusnm(''.join([' ' for _ in range(len(username))]))
-        if idx == 0:
-            recv_template = f"[{obtntime()}] {formusnm(username)} > {line}"
-        else:
+        recv_template = f"[{obtntime()}] {formusnm(username)} > {line}"
+        if idx > 0:
             recv_template = f"[{obtntime()}] {formusnm(filling_username)} > {line}"
         print(recv_template)
 

--- a/cnew.py
+++ b/cnew.py
@@ -50,7 +50,10 @@ async def producer_handler(cphrsuit, websocket, username, chatroom, servaddr):
     footelem = HTML("<b>[" + chatroom + "]</b>" + " " + username.strip() + " - Sanctuary ZERO v04092020 running on '" + servaddr + "' - Hit Ctrl+C to EXIT")
     while True:
         with patch_stdout():
-            mesgtext = await sess.prompt_async(lambda:"[" + obtntime() + "] " + formusnm(str(username)) + " > ", bottom_toolbar=footelem, validator=emtyfind(), refresh_interval=0.5)
+            mesgtext = await sess.prompt_async(lambda:"[" + obtntime() + "] " + formusnm(str(username)) + " > ", bottom_toolbar=footelem,
+                                                                                                                 validator=emtyfind(),
+                                                                                                                 refresh_interval=0.5,
+                                                                                                                 prompt_continuation=lambda width, line_number, is_soft_wrap: ' ' * width)
         senddata = json.dumps({"username": username.strip(), "chatroom": chatroom, "mesgtext": mesgtext.strip()})
         senddata = cphrsuit.encrjson(senddata)
         await websocket.send(senddata)

--- a/cnew.py
+++ b/cnew.py
@@ -1,16 +1,15 @@
 import asyncio, websockets, time, json, click, secrets, os, sys
-from typing import List
 from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit import print_formatted_text, HTML
 from prompt_toolkit.validation import Validator, ValidationError
 from cryptography.fernet import Fernet, InvalidToken
 
-import textwrap
-
+from utils.helper_display import HelperDisplay
 
 sess = PromptSession()
 sepr = chr(969696)
+helper_display = HelperDisplay()
 
 
 class emtyfind(Validator):
@@ -41,7 +40,7 @@ async def consumer_handler(cphrsuit, websocket, username, chatroom, servaddr):
             else:
                 recvjson = json.loads(cphrsuit.decrjson(recvdata))
                 if recvjson["chatroom"] == chatroom and recvjson["username"] != username:
-                    display_mesgtext(recvjson["username"], recvjson["mesgtext"])
+                    print("[" + obtntime() + "] " + formusnm(recvjson["username"]) + " > " + helper_display.wrap_conversational_text(recvjson["mesgtext"]))
 
         except Exception as EXPT:
             pass
@@ -66,31 +65,6 @@ async def hello(servaddr, username, chatroom, password):
         await prod
         await cons
         asyncio.get_event_loop().run_forever()
-
-
-def wrap_msgtext(mesgtext: str, set_width: int = 80) -> List[str]:
-    """ Wrap text into list
-        text length is set and determined as a breakpoint
-    """
-    if not isinstance(mesgtext, str):
-        return []
-    return textwrap.wrap(mesgtext, width=set_width)
-
-
-def display_mesgtext(username: str, mesgtext: str) -> None:
-    """ Display user text on client side """
-    if not all([isinstance(mesgtext, str), isinstance(mesgtext, str)]):
-        return None
-
-    wrapped_lines = wrap_msgtext(mesgtext)
-    for idx, line in enumerate(wrapped_lines):
-        filling_username = formusnm(''.join([' ' for _ in range(len(username))]))
-        recv_template = f"[{obtntime()}] {formusnm(username)} > {line}"
-        if idx > 0:
-            recv_template = f"[{obtntime()}] {formusnm(filling_username)} > {line}"
-        print(recv_template)
-
-    return None
 
 
 def obtntime():

--- a/main.py
+++ b/main.py
@@ -2,9 +2,11 @@ import asyncio, websockets, sys, click, time, os
 from prompt_toolkit import print_formatted_text, HTML
 from websockets.exceptions import ConnectionClosedError
 
+from utils.helper_display import HelperDisplay
 
 USERS = {}
 sepr = chr(969696)
+helper_display = HelperDisplay()
 
 
 def obtntime():
@@ -30,25 +32,6 @@ async def notify_mesej(message):
     if USERS: await asyncio.wait([user.send(message) for user in USERS])
 
 
-def wrap_text(message, max_width, indent=24):
-    wrapped_message = str()
-    indent_text = str()
-    message_width = len(message)
-    width = max_width - indent
-
-    for i in range(indent):
-        indent_text += ' '
-
-    for i in range(0, message_width, width):
-        if i > 0:
-            wrapped_message += indent_text
-        wrapped_message += message[i : i + width]
-        if i < message_width - width:
-            wrapped_message += '\n'
-
-    return wrapped_message
-
-
 async def chatroom(websocket, path):
     if not websocket in USERS:
         USERS[websocket] = ""
@@ -60,8 +43,7 @@ async def chatroom(websocket, path):
                     print_formatted_text(HTML("[" + obtntime() + "] " + "<b>USERJOINED</b> > <green>" + mesgjson.split(sepr)[0] + "@" + mesgjson.split(sepr)[1] + "</green>"))
                     await notify_mesej("SNCTRYZERO" + sepr + "USERJOINED" + sepr + mesgjson.split(sepr)[0] + sepr + mesgjson.split(sepr)[1] + sepr + str(getallus(mesgjson.split(sepr)[1])))
             else:
-                terminal_columns = os.get_terminal_size()[0]
-                print_formatted_text(HTML("[" + obtntime() + "] " + "<b>SNCTRYZERO</b> > " + wrap_text(str(mesgjson), terminal_columns)))
+                print_formatted_text(HTML("[" + obtntime() + "] " + "<b>SNCTRYZERO</b> > " + helper_display.wrap_text(str(mesgjson))))
                 await notify_mesej(mesgjson)
     except ConnectionClosedError as EXPT:
         print_formatted_text(HTML("[" + obtntime() + "] " + "<b>USEREXITED</b> > <red>" + USERS[websocket][0] + "@" + USERS[websocket][1] + "</red>"))

--- a/utils/helper_display.py
+++ b/utils/helper_display.py
@@ -1,0 +1,57 @@
+"""
+FILE: helper_display.py
+DESCRIPTION: A utilities to help text display
+DATE: 17-Oct-2020
+"""
+import os
+import textwrap
+from typing import List
+
+
+class HelperDisplay:
+    """
+    Utilitiy Helper for Displaying Data
+    Current methods:
+        1.) wrap_text
+        2.) wrap_conversational_text
+        3.) _get_width -> internal use
+    """
+
+    def wrap_text(self, message: str, indent: int = 24) -> str:
+        """ Wrap general texts """
+        wrapped_message = str()
+        indent_text = ' ' * indent
+        message_width = len(message)
+        width = self._get_width(indent)
+
+        for i in range(0, message_width, width):
+            if i > 0:
+                wrapped_message += indent_text
+            wrapped_message += message[i : i + width]
+            if i < message_width - width:
+                wrapped_message += '\n'
+
+        return wrapped_message
+    
+    def wrap_conversational_text(self, message: str, indent: int = 24) -> str:
+        """ Wrap conversational texts which are broken by words """
+        width = self._get_width(indent)
+        wrapped_lines = textwrap.wrap(message, width=width)
+
+        if len(wrapped_lines) == 1:
+            wrapped_message = self.wrap_text(wrapped_lines[0])
+            return wrapped_message
+
+        wrapped_message = str()
+        for idx, line in enumerate(wrapped_lines):
+            indent_text = ' ' * indent if idx > 0 else ''
+            new_line = '\n' if idx < len(line)-1 else ''
+            indented_line = indent_text + line + new_line
+            wrapped_message += indented_line
+
+        return wrapped_message
+    
+    def _get_width(self, indent: int = 24) -> int:
+        """ Get the current width based on the terminal size """
+        max_width = os.get_terminal_size()[0]
+        return max_width - indent

--- a/utils/helper_display.py
+++ b/utils/helper_display.py
@@ -1,6 +1,6 @@
 """
 FILE: helper_display.py
-DESCRIPTION: A utilities to help text display
+DESCRIPTION: Utilities to help text display
 DATE: 17-Oct-2020
 """
 import os
@@ -10,7 +10,7 @@ from typing import List
 
 class HelperDisplay:
     """
-    Utilitiy Helper for Displaying Data
+    Utility Helper for Displaying Data
     Current methods:
         1.) wrap_text
         2.) wrap_conversational_text

--- a/utils/helper_display.py
+++ b/utils/helper_display.py
@@ -45,7 +45,7 @@ class HelperDisplay:
         wrapped_message = str()
         for idx, line in enumerate(wrapped_lines):
             indent_text = ' ' * indent if idx > 0 else ''
-            new_line = '\n' if idx < len(line)-1 else ''
+            new_line = '\n' if idx < len(wrapped_lines)-1 else ''
             indented_line = indent_text + line + new_line
             wrapped_message += indented_line
 


### PR DESCRIPTION
**Related Issue:**:

- #25 

**Fixes and Features:**

- [x] Add indentation for a conversational long text  (client-side)
- [x] Add utility as helper
- [x] Add type hints

**Tests**

- [x] Windows10's console -> it seemed to work properly

**Screenshot**

- client

![image](https://user-images.githubusercontent.com/9074112/96328977-49327f00-107b-11eb-8b4f-aae5c59e035c.png)

- server

![image](https://user-images.githubusercontent.com/9074112/96328980-57809b00-107b-11eb-84b2-f6416b31a9a4.png)



**Additional Explanation**

Using **textwrap** lib allows conversational texts to be presented properly since it breaks texts word by word.

